### PR TITLE
fix(Caddyfile): make non-static route to render

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -2,6 +2,10 @@ surveyit.co.kr {
     root * /srv
     file_server
     encode gzip
+    @notStatic {
+        not file
+    }
+    rewrite @notStatic /index.html
 }
 
 api.surveyit.co.kr {


### PR DESCRIPTION
/login/success 등의 react router 경로가 Caddy 서버에서 찾지 못하는 경우가 발생합니다.

원래 notStatic 파일들은 index에서 react가 알아서 찾도록 설정을 추가해줘야 합니다.

따라서 이를 수정했습니다.